### PR TITLE
Fix chat formatting for readability

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,700');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Noto+Sans:wght@400;600;700&display=swap');
 
 * {
     box-sizing: border-box;
@@ -7,7 +7,10 @@
 body {
     padding: 0;
     margin: 0;
-    font-family: 'Open Sans', sans-serif;
+    /* Prefer fonts with excellent Cyrillic support; fall back to system */
+    font-family: 'Inter', 'Noto Sans', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+        'Noto Sans', 'Liberation Sans', 'DejaVu Sans', 'Nimbus Sans', 'Apple Color Emoji', 'Segoe UI Emoji',
+        'Segoe UI Symbol', sans-serif;
 }
 
 main {

--- a/views/chat.ejs
+++ b/views/chat.ejs
@@ -16,7 +16,7 @@
                     </div>
                 </aside>
                 <section class="column">
-                    <div id="messages" class="box" style="white-space: pre-wrap"></div>
+                    <div id="messages" class="box"></div>
                     <form id="sendForm" class="field has-addons">
                         <div class="control is-expanded">
                             <input
@@ -440,11 +440,15 @@
                             if (line.startsWith('event:')) {
                                 eventType = line.slice(6).trim().replace(/\r/g, '');
                             } else if (line.startsWith('data:')) {
+                                // Per SSE spec, "data:" lines may be repeated and concatenated with newline separators.
+                                // Some servers prefix a single space after colon. Strip one leading space if present.
                                 const raw = line.slice(5).replace(/\r/g, '');
-                                dataLines.push(raw);
+                                const noLead = raw.startsWith(' ') ? raw.slice(1) : raw;
+                                dataLines.push(noLead);
                             }
                         }
-                        const data = dataLines.join('');
+                        // Join with newline per HTML Living Standard when multiple data lines are present
+                        const data = dataLines.join('\n');
                         if (eventType === 'done') {
                             // collapse reasoning when stream completes
                             if (assistant.thinkDetails) {
@@ -488,12 +492,15 @@
                                     assistant.thinkDetails.style.display = '';
                                     assistant.thinkDetails.open = true;
                                 }
+                                // Preserve newlines faithfully in <pre> block
                                 assistant.thinkEl.textContent += data;
                             }
                         } else {
                             // During streaming render as plain text for stability; finalize formatting on 'done'
-                            assistant.answerBuf += data;
-                            assistant.answerEl.textContent = assistant.answerBuf;
+                            if (data) {
+                                assistant.answerBuf += data;
+                                assistant.answerEl.textContent = assistant.answerBuf;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Improve chat readability by fixing SSE stream parsing/framing and font support to correctly render spacing, newlines, and Cyrillic text in messages and reasoning.

The previous SSE implementation and font stack led to mashed words, incorrect spacing, and missing newlines, particularly noticeable in non-Latin languages like Russian, as demonstrated in the user's example. This PR ensures proper text flow and character display.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca04bd0b-fb19-49f8-a222-514f05a6d259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca04bd0b-fb19-49f8-a222-514f05a6d259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

