### PR TITLE
Fix menu highlight and add public game route

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -420,6 +420,20 @@ body {
     color: var(--primary) !important;
 }
 
+/* Theme-aware navbar hover/active background and text color */
+[data-theme='light'] .navbar .navbar-item:hover,
+[data-theme='light'] .navbar .navbar-item.is-active,
+[data-theme='light'] .navbar .navbar-item.active {
+    background-color: color-mix(in srgb, var(--primary) 10%, transparent) !important;
+    color: var(--primary) !important;
+}
+[data-theme='dark'] .navbar .navbar-item:hover,
+[data-theme='dark'] .navbar .navbar-item.is-active,
+[data-theme='dark'] .navbar .navbar-item.active {
+    background-color: color-mix(in srgb, var(--primary) 22%, transparent) !important;
+    color: var(--primary) !important;
+}
+
 /* Theme toggle button (optional positioning) */
 .theme-toggle {
     position: fixed;

--- a/routes/views.js
+++ b/routes/views.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const isAuth = require('../middleware/is-auth');
+const https = require('https');
 
 const router = express.Router();
 
@@ -12,6 +13,52 @@ router.get('/', (req, res) => {
 
 router.get('/chat', isAuth, (req, res) => {
     res.render('chat', { pageTitle: 'Chat', path: '/chat' });
+});
+
+// Public route serving the latest game client HTML from GitHub
+router.get('/game', async (req, res, next) => {
+    const rawBase = 'https://raw.githubusercontent.com/novitsky-413x/c-dungeon/main/';
+    const htmlUrl = rawBase + 'webclient.html';
+
+    function fetchWithRedirect(url, maxRedirects = 3) {
+        return new Promise((resolve, reject) => {
+            const get = (targetUrl, redirectsLeft) => {
+                https
+                    .get(targetUrl, (resp) => {
+                        const status = resp.statusCode || 0;
+                        if (status >= 300 && status < 400 && resp.headers.location && redirectsLeft > 0) {
+                            resp.resume();
+                            return get(resp.headers.location, redirectsLeft - 1);
+                        }
+                        if (status < 200 || status > 299) {
+                            return reject(new Error('Failed to fetch: ' + status));
+                        }
+                        const chunks = [];
+                        resp.on('data', (d) => chunks.push(d));
+                        resp.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+                    })
+                    .on('error', reject);
+            };
+            get(url, maxRedirects);
+        });
+    }
+
+    try {
+        let html = await fetchWithRedirect(htmlUrl);
+        // Ensure relative asset URLs resolve against the GitHub raw base
+        if (html.includes('<head')) {
+            html = html.replace(
+                /<head(\s*[^>]*)>/i,
+                (m) => `${m}<base href="${rawBase}">`
+            );
+        } else {
+            html = `<head><base href="${rawBase}"></head>` + html;
+        }
+        res.set('Content-Type', 'text/html; charset=utf-8');
+        return res.send(html);
+    } catch (err) {
+        return next(err);
+    }
 });
 
 module.exports = router;

--- a/views/includes/navigation.ejs
+++ b/views/includes/navigation.ejs
@@ -1,6 +1,7 @@
-<nav class="navbar is-light" role="navigation" aria-label="main navigation">
+<nav class="navbar" role="navigation" aria-label="main navigation">
     <div class="navbar-brand">
         <a class="navbar-item <%= path === '/' ? 'is-active active' : '' %>" href="/" <%= path === '/' ? 'aria-current="page"' : '' %>>Home</a>
+        <a class="navbar-item <%= path === '/game' ? 'is-active active' : '' %>" href="/game" <%= path === '/game' ? 'aria-current="page"' : '' %>>Game</a>
         <% if (isAuthenticated) { %>
         <a class="navbar-item <%= path === '/chat' ? 'is-active active' : '' %>" href="/chat" <%= path === '/chat' ? 'aria-current="page"' : '' %>>Chat</a>
         <% } %>


### PR DESCRIPTION
Fix dark mode menu highlighting and add a public `/game` route to display the GitHub-hosted game client.

The `/game` route fetches the latest `webclient.html` directly from GitHub and injects a `<base>` tag to ensure all relative assets (scripts, styles, images) within the game client HTML correctly resolve against the GitHub raw content URL. This allows the user to update their game client on GitHub and have it immediately reflected in the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c4ac193-e81c-4c46-bad7-40b00f728951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c4ac193-e81c-4c46-bad7-40b00f728951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

